### PR TITLE
crash when launching SettingsActivity from ThingsActivity on Android 10

### DIFF
--- a/app/src/main/java/com/ywwynm/everythingdone/activities/SettingsActivity.java
+++ b/app/src/main/java/com/ywwynm/everythingdone/activities/SettingsActivity.java
@@ -242,7 +242,7 @@ public class SettingsActivity extends EverythingDoneBaseActivity {
     }
 
     private static boolean isFileRingtone(RingtoneManager ringtoneManager, Uri uri) {
-        return uri != RingtoneManager.getDefaultUri(RingtoneManager.TYPE_NOTIFICATION)
+        return !uri.equals(RingtoneManager.getDefaultUri(RingtoneManager.TYPE_NOTIFICATION))
                 && ringtoneManager.getRingtonePosition(uri) == -1;
     }
 


### PR DESCRIPTION
fix: crash when launching SettingsActivity from ThingsActivity on Android 10